### PR TITLE
Adds support for GNOME 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
     "name": "Window on Top",
     "description": "Simple top panel button for toggling Always on Top for windows.",
     "version": 6,
-    "shell-version": ["45", "46", "47"],
+    "shell-version": ["45", "46", "47", "48"],
     "url": "https://github.com/uosyph/window-on-top"
 }


### PR DESCRIPTION
# Changes
- Updated `shell-version` property in `metadata.json` by adding GNOME version `48`

## Tests
- Basic Sanity on Fedora 42 (GNOME 48.4)