### PR TITLE
feat: Add support for gnome 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
     "name": "Window on Top",
     "description": "Simple top panel button for toggling Always on Top for windows.",
     "version": 7,
-    "shell-version": ["45", "46", "47", "48"],
+    "shell-version": ["45", "46", "47", "48", "49"],
     "url": "https://github.com/uosyph/window-on-top"
 }


### PR DESCRIPTION

This PR adds support for GNOME 49 to window-on-top. The following changes were made:

    Updated metadata.json to include GNOME 49 compatibility.
  

