### PR TITLE
Fix to make the extension work with gnome 50

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -22,6 +22,9 @@ export default class WindowOnTopExtension extends Extension {
         this._indicator.connect('button-press-event', this._buttonClicked.bind(this));
         this._indicator.connect('captured-event', this._handleCapturedEvent.bind(this));  // Add captured event connection
 
+        // Make sure button-press-event is propagated correctly on gnome 49 and 50        
+        this._indicator.clear_actions()
+        
         this._topIcon = this._createIcon(`${this.path}/icons/top-symbolic.svg`);
         this._defaultIcon = this._createIcon(`${this.path}/icons/default-symbolic.svg`);
 

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "window-on-top@yousafesaeed.github.io",
     "name": "Window on Top",
     "description": "Simple top panel button for toggling Always on Top for windows.",
-    "version": 8,
-    "shell-version": ["45", "46", "47", "48", "49"],
+    "version": 9,
+    "shell-version": ["45", "46", "47", "48", "49", "50"],
     "url": "https://github.com/uosyph/window-on-top"
 }


### PR DESCRIPTION
Added a call to clear_actions() on the indicator object which seems to make the button-press-event get triggered correctly again.
